### PR TITLE
Feat#7 transaction list page layout

### DIFF
--- a/bank-poke/src/components/TableLayout.vue
+++ b/bank-poke/src/components/TableLayout.vue
@@ -1,0 +1,55 @@
+<template>
+  <div class="container border rounded-3 overflow-hidden p-0">
+    <ul class="nav nav-tabs nav-justified">
+      <!-- 각 탭 추가 -->
+      <li
+        class="nav-item"
+        v-for="tab in tabs"
+        :key="tab.label"
+        @click="currentTab = tab.name"
+      >
+        <a
+          class="nav-link"
+          :class="{ active: currentTab === tab.name }"
+          href="#"
+        >
+          {{ tab.name }}
+          <span
+            class="badge rounded-pill"
+            :class="currentTab === tab.name ? 'bg-primary' : 'bg-secondary'"
+            >{{ tab.count }}</span
+          >
+          <div
+            class="fw-bold"
+            :class="{
+              textBlue: tab.name === '수입',
+              textRed: tab.name === '지출',
+            }"
+          >
+            {{ tab.amount.toLocaleString() }}원
+          </div>
+        </a>
+      </li>
+    </ul>
+    <slot :currentTab="currentTab"></slot>
+  </div>
+</template>
+<script setup>
+import { ref } from 'vue';
+const currentTab = ref('전체');
+
+defineProps({
+  tabs: Array,
+});
+</script>
+<style scoped>
+.nav-link {
+  color: black;
+}
+.textBlue {
+  color: #007bff;
+}
+.textRed {
+  color: #dc3545;
+}
+</style>

--- a/bank-poke/src/pages/TransactionList.vue
+++ b/bank-poke/src/pages/TransactionList.vue
@@ -5,32 +5,34 @@
     <div class="d-flex">
       <!-- 년월 이동 pagination -->
       <ul class="pagination pagination-sm mb-0 me-2 custom-pagination">
-        <li class="page-item">
+        <li class="page-item" @click="shiftYear(-1)">
           <a class="page-link" href="#"
             ><i class="fa-solid fa-angles-left"></i
           ></a>
         </li>
-        <li class="page-item">
+        <li class="page-item" @click="shiftMonth(-1)">
           <a class="page-link" href="#"
             ><i class="fa-solid fa-angle-left"></i
           ></a>
         </li>
         <li class="page-item">
-          <a class="page-link" href="#">2025-04</a>
+          <a class="page-link" href="#">{{ formattedDate }}</a>
         </li>
-        <li class="page-item">
+        <li class="page-item" @click="shiftMonth(1)">
           <a class="page-link" href="#"
             ><i class="fa-solid fa-angle-right"></i
           ></a>
         </li>
-        <li class="page-item">
+        <li class="page-item" @click="shiftYear(1)">
           <a class="page-link" href="#"
             ><i class="fa-solid fa-angles-right"></i
           ></a>
         </li>
       </ul>
       <!-- '이번달' 버튼 -->
-      <button class="btn btn-sm rounded-3 custom-btn">이번달</button>
+      <button class="btn btn-sm rounded-3 custom-btn" @click="goToNow">
+        이번달
+      </button>
     </div>
     <!-- 검색 버튼 -->
     <button class="btn btn-sm rounded-circle custom-btn">
@@ -39,7 +41,7 @@
   </div>
   <!-- 거래 내역 테이블 -->
   <TableLayout :tabs="tabs">
-    <template>
+    <template v-slot:default="slotProps">
       <table class="table table-hover mb-0">
         <thead>
           <tr>
@@ -53,16 +55,29 @@
             <th>금액</th>
           </tr>
         </thead>
-        <tbody>
-          <tr>
+        <tbody
+          v-if="
+            state.user && transactionsByType(slotProps.currentTab).length > 0
+          "
+        >
+          <tr
+            v-for="tr in transactionsByType(slotProps.currentTab)"
+            :key="tr.id"
+            @click=""
+          >
             <td>
-              <input type="checkbox" />
+              <input type="checkbox" :value="tr.id" />
             </td>
-            <td>2025-04-08</td>
-            <td>카드</td>
-            <td>식비</td>
-            <td>버거킹</td>
-            <td>11,000원</td>
+            <td>{{ tr.date }}</td>
+            <td>{{ asset(tr.asset_type, tr.assetId) }}</td>
+            <td>{{ tr.category }}</td>
+            <td>{{ tr.name }}</td>
+            <td>{{ tr.amount }}원</td>
+          </tr>
+        </tbody>
+        <tbody v-else>
+          <tr>
+            <td colspan="6" class="text-center">데이터가 없습니다.</td>
           </tr>
         </tbody>
       </table>
@@ -71,26 +86,97 @@
 </template>
 
 <script setup>
+import { ref, computed } from 'vue';
+import { useUserStore } from '@/stores/user.js';
 import TableLayout from '@/components/TableLayout.vue';
 
-// 탭 테스트 데이터
-const tabs = [
+const { state } = useUserStore();
+const user = computed(() => state.user);
+
+// 탭 데이터
+const tabs = computed(() => [
   {
     name: '전체',
-    count: 0,
-    amount: 0,
+    count: transactionsByPeriod.value.length,
+    amount: transactionsByPeriod.value.reduce((sum, t) => sum + t.amount, 0),
   },
   {
     name: '수입',
-    count: 0,
-    amount: 0,
+    count: transactionsByType('수입').length,
+    amount: transactionsByType('수입').reduce((sum, t) => sum + t.amount, 0),
   },
   {
     name: '지출',
-    count: 0,
-    amount: 0,
+    count: transactionsByType('지출').length,
+    amount: transactionsByType('지출').reduce((sum, t) => sum + t.amount, 0),
   },
-];
+]);
+
+// 어떤 자산인지 계산하여 반환
+const asset = computed(() => {
+  return (type, id) => {
+    if (type === 'card') {
+      const card = user.value.asset_group.card.find((c) => c.id === id);
+      return card ? (card.isCheck ? '체크카드' : '신용카드') : '';
+    } else if (type === 'cash') {
+      return '현금';
+    } else if (type === 'account') {
+      const account = user.value.asset_group.account.find((a) => a.id === id);
+      return account ? account.name : '';
+    } else if (type === 'etc') {
+      const assetEtc = user.value.asset_group.etc.find((i) => i.id === id);
+      return assetEtc ? assetEtc.name : '';
+    }
+    return '기타';
+  };
+});
+
+// 현재 표시되는(선택한) 날짜
+const currentDate = ref(new Date());
+
+// YYYY-MM 형식으로 포맷
+const formattedDate = computed(() => {
+  const year = currentDate.value.getFullYear();
+  const month = String(currentDate.value.getMonth() + 1).padStart(2, '0');
+  return `${year}-${month}`;
+});
+
+const shiftMonth = (direction) => {
+  currentDate.value.setMonth(currentDate.value.getMonth() + direction);
+  currentDate.value = new Date(currentDate.value);
+};
+
+const shiftYear = (direction) => {
+  currentDate.value.setFullYear(currentDate.value.getFullYear() + direction);
+  currentDate.value = new Date(currentDate.value);
+};
+
+const goToNow = () => {
+  currentDate.value = new Date();
+};
+
+// 년월별로 필터링된 거래 내역
+const transactionsByPeriod = computed(() => {
+  if (!state.user || !state.user.transactions) return [];
+
+  const currentYear = currentDate.value.getFullYear();
+  const currentMonth = currentDate.value.getMonth() + 1;
+
+  return state.user.transactions.filter((ts) => {
+    const [year, month] = ts.date.split('-').map(Number); // 현재 yyyy-mm-dd 형식으로 계산
+    return year === currentYear && month === currentMonth;
+  });
+});
+
+// 수입/지출별로 필터링된 거래 내역
+const transactionsByType = (type) => {
+  if (type === '수입') {
+    return transactionsByPeriod.value.filter((t) => t.type === 'income');
+  } else if (type === '지출') {
+    return transactionsByPeriod.value.filter((t) => t.type === 'expense');
+  }
+  return transactionsByPeriod.value;
+};
 </script>
 
 <style scoped>

--- a/bank-poke/src/pages/TransactionList.vue
+++ b/bank-poke/src/pages/TransactionList.vue
@@ -1,0 +1,117 @@
+<template>
+  <h5 class="my-3">거래 내역</h5>
+  <!-- 거래 내역 헤더: 년월 이동 pagination + '이번달' 버튼 + 검색 버튼 -->
+  <div class="d-flex justify-content-between mb-3">
+    <div class="d-flex">
+      <!-- 년월 이동 pagination -->
+      <ul class="pagination pagination-sm mb-0 me-2 custom-pagination">
+        <li class="page-item">
+          <a class="page-link" href="#"
+            ><i class="fa-solid fa-angles-left"></i
+          ></a>
+        </li>
+        <li class="page-item">
+          <a class="page-link" href="#"
+            ><i class="fa-solid fa-angle-left"></i
+          ></a>
+        </li>
+        <li class="page-item">
+          <a class="page-link" href="#">2025-04</a>
+        </li>
+        <li class="page-item">
+          <a class="page-link" href="#"
+            ><i class="fa-solid fa-angle-right"></i
+          ></a>
+        </li>
+        <li class="page-item">
+          <a class="page-link" href="#"
+            ><i class="fa-solid fa-angles-right"></i
+          ></a>
+        </li>
+      </ul>
+      <!-- '이번달' 버튼 -->
+      <button class="btn btn-sm rounded-3 custom-btn">이번달</button>
+    </div>
+    <!-- 검색 버튼 -->
+    <button class="btn btn-sm rounded-circle custom-btn">
+      <i class="fa-solid fa-magnifying-glass"></i>
+    </button>
+  </div>
+  <!-- 거래 내역 테이블 -->
+  <TableLayout :tabs="tabs">
+    <template>
+      <table class="table table-hover mb-0">
+        <thead>
+          <tr>
+            <th>
+              <input type="checkbox" />
+            </th>
+            <th>날짜</th>
+            <th>자산</th>
+            <th>분류</th>
+            <th>내용</th>
+            <th>금액</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <input type="checkbox" />
+            </td>
+            <td>2025-04-08</td>
+            <td>카드</td>
+            <td>식비</td>
+            <td>버거킹</td>
+            <td>11,000원</td>
+          </tr>
+        </tbody>
+      </table>
+    </template>
+  </TableLayout>
+</template>
+
+<script setup>
+import TableLayout from '@/components/TableLayout.vue';
+
+// 탭 테스트 데이터
+const tabs = [
+  {
+    name: '전체',
+    count: 0,
+    amount: 0,
+  },
+  {
+    name: '수입',
+    count: 0,
+    amount: 0,
+  },
+  {
+    name: '지출',
+    count: 0,
+    amount: 0,
+  },
+];
+</script>
+
+<style scoped>
+/* pagination 스타일 조정 */
+.custom-pagination .page-link {
+  color: #333;
+  border: 1px solid #6c757d;
+  padding: 5px 10px;
+  font-size: 0.9rem;
+}
+.page-item:first-child .page-link {
+  border-radius: 0.5rem 0 0 0.5rem;
+}
+.page-item:last-child .page-link {
+  border-radius: 0 0.5rem 0.5rem 0;
+}
+/* 버튼 스타일 조정 */
+.custom-btn {
+  border: 1px solid #6c757d;
+}
+.custom-btn:hover {
+  background-color: #f1f1f1;
+}
+</style>


### PR DESCRIPTION
Feat(issue #7): 거래 내역 페이지 구현

## 🔘Part

- [x] Feat

<br/>

## 🔎 작업 내용

- 거래 내역 전체/수입/지출 별로 표시
- 년월기준으로 표시

  <br/>

## 이미지 첨부

![image](https://github.com/user-attachments/assets/ec7bb97b-2e69-447a-a481-9b1762d5d6b7)

<br/>

## 🔧 앞으로의 과제

- 검색 기능
- 컬럼별 정렬 기능
- 선택된 거래 삭제 기능 (전체선택, 특정 거래 선택)

  <br/>

## ➕ 이슈 링크

- #7

<br/>
